### PR TITLE
Remove reference to gh-pages branch

### DIFF
--- a/_episodes/05-github-pages.md
+++ b/_episodes/05-github-pages.md
@@ -133,16 +133,12 @@ Usually it's available instantly, but it can take a few seconds and in the worst
 > to your repository. You could do this on the command line or directly on GitHub. The
 > steps below are for working directly on GitHub:
 >
-> 1. Make sure you are working on the "gh-pages" branch. Select it from the menu if not:
->
->    ![Branch selector on GitHub](../fig/github-gh-pages.png)
->
-> 2. To add a new file directly on GitHub, press the "Create new file" button.
+> 1. To add a new file directly on GitHub, press the "Create new file" button.
 >
 >    ![Create new file on GitHub](../fig/github-create-new-file.png)
 >
-> 3. Name it 'test.html', add some HTML and click "Commit new file".
-> 4. Try opening `https://some-librarian.github.io/hello-world/test`
+> 2. Name it 'test.html', add some HTML and click "Commit new file".
+> 3. Try opening `https://some-librarian.github.io/hello-world/test`
 >    (replace "some-librarian" with your username).
 >    Notice that the HTML extension is not included.
 >


### PR DESCRIPTION
gh-pages branch is not required any more. A previous reference has been removed by PR #103, however there remained a leftover. This change removes that.